### PR TITLE
Refactor LCA pipeline to streamline midpoint calculations

### DIFF
--- a/LCA_GPT.py
+++ b/LCA_GPT.py
@@ -17,13 +17,12 @@ import shutil
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
-from openpyxl import load_workbook
 
 KEY_COLS = ["Time Frame", "SSPs", "RCPs", "Impact Categories"]
 
-def _get_unit_sheet(path: str) -> pd.DataFrame:
-    # Read without headers to handle the matrix layout.
-    return pd.read_excel(path, sheet_name="Unit process & Utilities", header=None)
+def _get_unit_sheet(xls: pd.ExcelFile) -> pd.DataFrame:
+    """Return the 'Unit process & Utilities' sheet without headers."""
+    return xls.parse(sheet_name="Unit process & Utilities", header=None)
 
 def _discover_u_columns(unit_df: pd.DataFrame) -> Dict[str, int]:
     """
@@ -60,8 +59,8 @@ def _get_coeff_vector(unit_df: pd.DataFrame, u_col: int, index_map: Dict[str, in
         coeffs[k] = 0.0 if pd.isna(val) else float(val)
     return coeffs
 
-def _read_sheet(path: str, sheet: str) -> pd.DataFrame:
-    return pd.read_excel(path, sheet_name=sheet)
+def _read_sheet(xls: pd.ExcelFile, sheet: str) -> pd.DataFrame:
+    return xls.parse(sheet_name=sheet)
 
 def _ensure_same_index(frames: List[pd.DataFrame]) -> pd.MultiIndex:
     """
@@ -96,45 +95,51 @@ def _to_indexed_series(df: pd.DataFrame, value_col: str) -> pd.Series:
         s = s.groupby(level=list(range(s.index.nlevels))).sum()
     return s
 
-def _compute_materials(path: str, m_coeffs: Dict[str, float]) -> pd.Series:
+def _sum_aligned(series_list: List[pd.Series]) -> pd.Series:
+    """Return the elementwise sum of series, aligning on their indexes."""
+    if not series_list:
+        return pd.Series(dtype=float)
+    if len(series_list) == 1:
+        return series_list[0]
+    return pd.concat(series_list, axis=1).fillna(0).sum(axis=1)
+
+def _compute_materials(xls: pd.ExcelFile, m_coeffs: Dict[str, float]) -> pd.Series:
     # Each M_k sheet has 'Impacts per kg/m³'
     series_list = []
     for m_name, qty in m_coeffs.items():
         sheet = f"{m_name}_Midpoint"
-        df = _read_sheet(path, sheet)
+        df = _read_sheet(xls, sheet)
         s = _to_indexed_series(df, "Impacts per kg/m³")
         series_list.append(s * qty)
     if not series_list:
         raise ValueError("No material sheets found.")
     # Align and sum
-    out = sum(s.reindex(series_list[0].index.union_many([x.index for x in series_list[1:]]), fill_value=0) for s in series_list)
-    return out
+    return _sum_aligned(series_list)
 
-def _compute_waste(path: str, w_coeffs: Dict[str, float]) -> pd.Series:
+def _compute_waste(xls: pd.ExcelFile, w_coeffs: Dict[str, float]) -> pd.Series:
     series_list = []
     for w_name, qty in w_coeffs.items():
         sheet = f"{w_name}_Midpoint"
-        df = _read_sheet(path, sheet)
+        df = _read_sheet(xls, sheet)
         s = _to_indexed_series(df, "Impacts per kg/m³")
         series_list.append(s * qty)
     if not series_list:
         # If no waste items, return zero series built from a template
         # Use W_1_Midpoint as template if present, else zero later
         try:
-            df = _read_sheet(path, "W_1_Midpoint")
+            df = _read_sheet(xls, "W_1_Midpoint")
             template = _to_indexed_series(df, "Impacts per kg/m³")
             return template * 0.0
         except Exception:
             raise ValueError("No waste sheets found and no template available.")
-    out = sum(s.reindex(series_list[0].index.union_many([x.index for x in series_list[1:]]), fill_value=0) for s in series_list)
-    return out
+    return _sum_aligned(series_list)
 
-def _compute_energy(path: str, e_coeffs: Dict[str, float]) -> pd.Series:
+def _compute_energy(xls: pd.ExcelFile, e_coeffs: Dict[str, float]) -> pd.Series:
     # Electricity, Heat, Steam each with 'Impacts per kWh'
     parts = []
     for name in ("Electricity", "Heat", "Steam"):
         try:
-            df = _read_sheet(path, f"{name}_Midpoint")
+            df = _read_sheet(xls, f"{name}_Midpoint")
             s = _to_indexed_series(df, "Impacts per kWh")
             qty = e_coeffs.get(name, 0.0)
             parts.append(s * qty)
@@ -145,33 +150,31 @@ def _compute_energy(path: str, e_coeffs: Dict[str, float]) -> pd.Series:
         # try to build a zero template from any of the energy sheets
         for name in ("Electricity", "Heat", "Steam"):
             try:
-                df = _read_sheet(path, f"{name}_Midpoint")
+                df = _read_sheet(xls, f"{name}_Midpoint")
                 tmpl = _to_indexed_series(df, "Impacts per kWh")
                 return tmpl * 0.0
             except Exception:
                 continue
         raise ValueError("No energy sheets found.")
-    out = sum(s.reindex(parts[0].index.union_many([x.index for x in parts[1:]]), fill_value=0) for s in parts)
-    return out
+    return _sum_aligned(parts)
 
-def _compute_transport(path: str, t_coeffs: Dict[str, float]) -> pd.Series:
+def _compute_transport(xls: pd.ExcelFile, t_coeffs: Dict[str, float]) -> pd.Series:
     # Transportation_Midpoint has columns T_1, T_2, ... (if more added later)
-    df = _read_sheet(path, "Transportation_Midpoint")
+    df = _read_sheet(xls, "Transportation_Midpoint")
     df = df.copy()
     # Keep only T_* columns present
     t_cols = [c for c in df.columns if isinstance(c, str) and c.startswith("T_")]
     if not t_cols:
         # Build zero template using any sheet previously seen: fallback to electricity or a materials sheet
         try:
-            tmpl = _to_indexed_series(_read_sheet(path, "Electricity_Midpoint"), "Impacts per kWh")
+            tmpl = _to_indexed_series(_read_sheet(xls, "Electricity_Midpoint"), "Impacts per kWh")
             return tmpl * 0.0
         except Exception:
             # Final fallback: first materials sheet
-            xls = pd.ExcelFile(path)
             m_sheet = next((s for s in xls.sheet_names if s.startswith("M_") and s.endswith("_Midpoint")), None)
             if m_sheet is None:
                 raise ValueError("Cannot construct transport template; no suitable sheet found.")
-            tmpl = _to_indexed_series(_read_sheet(path, m_sheet), "Impacts per kg/m³")
+            tmpl = _to_indexed_series(_read_sheet(xls, m_sheet), "Impacts per kg/m³")
             return tmpl * 0.0
     # Build rowwise dot product
     # Align index first
@@ -183,22 +186,21 @@ def _compute_transport(path: str, t_coeffs: Dict[str, float]) -> pd.Series:
     out.index = base_idx
     return out
 
-def _compute_emissions(path: str, e_coeffs: Dict[str, float]) -> pd.Series:
+def _compute_emissions(xls: pd.ExcelFile, e_coeffs: Dict[str, float]) -> pd.Series:
     # Emissions_Midpoint has columns E_1 .. E_n
-    df = _read_sheet(path, "Emissions_Midpoint")
+    df = _read_sheet(xls, "Emissions_Midpoint")
     df = df.copy()
     e_cols = [c for c in df.columns if isinstance(c, str) and c.startswith("E_")]
     if not e_cols:
         # Build zero template
         try:
-            tmpl = _to_indexed_series(_read_sheet(path, "Electricity_Midpoint"), "Impacts per kWh")
+            tmpl = _to_indexed_series(_read_sheet(xls, "Electricity_Midpoint"), "Impacts per kWh")
             return tmpl * 0.0
         except Exception:
-            xls = pd.ExcelFile(path)
             m_sheet = next((s for s in xls.sheet_names if s.startswith("M_") and s.endswith("_Midpoint")), None)
             if m_sheet is None:
                 raise ValueError("Cannot construct emissions template; no suitable sheet found.")
-            tmpl = _to_indexed_series(_read_sheet(path, m_sheet), "Impacts per kg/m³")
+            tmpl = _to_indexed_series(_read_sheet(xls, m_sheet), "Impacts per kg/m³")
             return tmpl * 0.0
     base_idx = pd.MultiIndex.from_frame(df[KEY_COLS])
     vals = pd.DataFrame({c: _to_indexed_series(df, c).reindex(base_idx) for c in e_cols})
@@ -207,31 +209,8 @@ def _compute_emissions(path: str, e_coeffs: Dict[str, float]) -> pd.Series:
     out.index = base_idx
     return out
 
-def _template_index(path: str) -> pd.MultiIndex:
-    """
-    Pick a template sheet to extract the standard key rows.
-    Preference: Electricity_Midpoint -> any M_*_Midpoint -> Transportation_Midpoint.
-    """
-    for sheet, valcol in [("Electricity_Midpoint", "Impacts per kWh"),
-                          ("Heat_Midpoint", "Impacts per kWh"),
-                          ("Steam_Midpoint", "Impacts per kWh")]:
-        try:
-            df = _read_sheet(path, sheet)
-            return pd.MultiIndex.from_frame(df[KEY_COLS])
-        except Exception:
-            pass
-    # Try any M_* sheet
-    xls = pd.ExcelFile(path)
-    for s in xls.sheet_names:
-        if s.startswith("M_") and s.endswith("_Midpoint"):
-            df = _read_sheet(path, s)
-            return pd.MultiIndex.from_frame(df[KEY_COLS])
-    # Fallback: Transportation_Midpoint
-    df = _read_sheet(path, "Transportation_Midpoint")
-    return pd.MultiIndex.from_frame(df[KEY_COLS])
 
-def _assemble_ui_frame(path: str,
-                       material: pd.Series,
+def _assemble_ui_frame(material: pd.Series,
                        waste: pd.Series,
                        transport: pd.Series,
                        energy: pd.Series,
@@ -249,8 +228,6 @@ def _assemble_ui_frame(path: str,
     }
     df = pd.DataFrame(cols)
     df.insert(0, "Impact Categories", [ix[-1] for ix in df.index])  # quick add then will overwrite with full keys
-    # Put the full key columns from a template
-    template_idx = _template_index(path)
     # Build a DataFrame with KEY_COLS from index
     keys_df = pd.DataFrame(list(all_idx), columns=KEY_COLS)
     # Ensure ordering matches idx
@@ -262,12 +239,12 @@ def _assemble_ui_frame(path: str,
     df = df[ordered]
     return df
 
-def compute_ui_midpoint(path: str, ui_name: str) -> pd.DataFrame:
+def compute_ui_midpoint(xls: pd.ExcelFile, ui_name: str) -> pd.DataFrame:
     """
     Compute the Ui_Midpoint table for one U (e.g., 'U_1').
     Returns a DataFrame with columns KEY_COLS + five subcategories + total.
     """
-    unit_df = _get_unit_sheet(path)
+    unit_df = _get_unit_sheet(xls)
     u_cols = _discover_u_columns(unit_df)
     if ui_name not in u_cols:
         raise ValueError(f"{ui_name} not found in 'Unit process & Utilities' header. Found: {list(u_cols)}")
@@ -285,10 +262,10 @@ def compute_ui_midpoint(path: str, ui_name: str) -> pd.DataFrame:
     e_coeffs = _get_coeff_vector(unit_df, u_col, e_rows)
 
     # Compute each component
-    material = _compute_materials(path, m_coeffs)
-    waste = _compute_waste(path, w_coeffs)
-    transport = _compute_transport(path, t_coeffs)
-    energy = _compute_energy(path, {"Electricity": unit_df.iat[_find_row_indices(unit_df, "Electricity").get("Electricity", -1), u_col]
+    material = _compute_materials(xls, m_coeffs)
+    waste = _compute_waste(xls, w_coeffs)
+    transport = _compute_transport(xls, t_coeffs)
+    energy = _compute_energy(xls, {"Electricity": unit_df.iat[_find_row_indices(unit_df, "Electricity").get("Electricity", -1), u_col]
                                                if "Electricity" in unit_df.iloc[:,0].values else 0.0,
                                      "Heat": unit_df.iat[_find_row_indices(unit_df, "Heat").get("Heat", -1), u_col]
                                                if "Heat" in unit_df.iloc[:,0].values else 0.0,
@@ -297,19 +274,16 @@ def compute_ui_midpoint(path: str, ui_name: str) -> pd.DataFrame:
     # Coerce NaNs to 0
     energy = energy.fillna(0.0)
 
-    emission = _compute_emissions(path, e_coeffs)
+    emission = _compute_emissions(xls, e_coeffs)
 
     # Assemble
-    ui_df = _assemble_ui_frame(path, material, waste, transport, energy, emission)
+    ui_df = _assemble_ui_frame(material, waste, transport, energy, emission)
     return ui_df
 
 def run_lca(path: str, ui_list: Optional[List[str]] = None, write_back: bool = True, make_backup: bool = True) -> Dict[str, pd.DataFrame]:
-    """
-    Main entry point. Computes Ui_Midpoint for all discovered U_* (or a provided subset).
-    Returns a dict mapping sheet_name -> DataFrame.
-    If write_back=True, updates/creates 'U_i_Midpoint' sheets in-place (optionally after making a .bak copy).
-    """
-    unit_df = _get_unit_sheet(path)
+    """Main entry point. Computes Ui_Midpoint for selected U_* and optionally writes back."""
+    xls = pd.ExcelFile(path)
+    unit_df = _get_unit_sheet(xls)
     u_cols = _discover_u_columns(unit_df)
     if not u_cols:
         raise ValueError("No U_* columns discovered in 'Unit process & Utilities'.")
@@ -317,7 +291,7 @@ def run_lca(path: str, ui_list: Optional[List[str]] = None, write_back: bool = T
 
     results: Dict[str, pd.DataFrame] = {}
     for ui in chosen:
-        df = compute_ui_midpoint(path, ui)
+        df = compute_ui_midpoint(xls, ui)
         results[f"{ui}_Midpoint"] = df
 
     if write_back:


### PR DESCRIPTION
## Summary
- Avoid repeated Excel loads by reusing a single `pd.ExcelFile` handle across calculations
- Replace invalid `union_many` usage with `_sum_aligned` helper for safe Series alignment and summation
- Simplify transport and emissions computations and streamline `run_lca` orchestration

## Testing
- `python test_LCA.py`
- `python - <<'PY'
import LCA_GPT as lca
res=lca.run_lca('20250408-dsRNA in vitro synthesis-LCA calculation.xlsx', ui_list=['U_1'], write_back=False)
print({k: v.shape for k, v in res.items()})
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a3473213883219a0af1d66e06d5d3